### PR TITLE
fix typo in filename in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ while getopts ":lv:" opt ;do
                 echo -e "Downloading Virtual image\n"
                 cd ./images
                 wget -c http://www.akulpillai.com/how2kernel/x86_64.tar.gz
-                tar xvf x84_64.tar.gz
+                tar xvf x86_64.tar.gz
                 cd ../
                 
                 echo "Building for x86"


### PR DESCRIPTION
I fixed a typo in the file that was downloaded in the previous line.